### PR TITLE
DPU statistics and new reader implementation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ So if you wanted to use the DPUs with 5 tasklets, the command would be: `make US
 
 Note that due a bug in the build process (Issue #1), the build will fail the first time around if using PIM. Simply run the `make` command twice to get the build to succeed. 
 
-If remaking with a different NR_TASKLETS, make sure to run `make clean` instead of `make` to rebuild the dpu binary file.
+If remaking with a different NR_TASKLETS, make sure to run `make clean` or simply delete `decompress.dpu` `make` to make sure the binary file is rebuilt with the new number of tasklets.
 
 ## Run
 To execute the program, run the following command:
 ```
-./reader -f [ORC input test file] -t [Maximum number of threads to use in the ORC reader, default is 1]
+./reader -f [ORC input test file] -t [number of rows assigned to thread / 10000]
 ```
+10000 is the size of the stride of the snappy reader. 
 The program output should look something like this:
 <img width="717" alt="orc-parser-output" src="https://user-images.githubusercontent.com/25714353/103724599-90008880-4f89-11eb-936a-2e2ed499f5e2.png">

--- a/orc-parser/reader.cc
+++ b/orc-parser/reader.cc
@@ -19,7 +19,7 @@ struct thread_args {
 	int thread_num;
 	char* filename;
 	uint64_t start_row_number;
-	uint64_t end_row_number
+	uint64_t end_row_number;
 	uint64_t sum;
 };
 
@@ -50,7 +50,7 @@ void *read_thread(void *arg) {
 	LongVectorBatch *first_col = dynamic_cast<LongVectorBatch *>(root->fields[0]); // Get first column
 
 	// read the rows
-	for (uint64_t row = start_row_number;  row <= end_row_number; row++) {
+	for (uint64_t row = args->start_row_number;  row <= args->end_row_number; row++) {
 		if (!rowReader->next(*batch))
 			break;
 		
@@ -105,6 +105,8 @@ int main(int argc, char *argv[]) {
 	}
 
 	uint64_t active_threads = total_num_rows / ROWS_PER_THREAD;
+	if (total_num_rows % ROWS_PER_THREAD != 0)
+		active_threads ++;
 
 	struct thread_args *thread_args = (struct thread_args *)malloc(sizeof(struct thread_args) * active_threads);
 	pthread_t *threads = (pthread_t *)malloc(sizeof(pthread_t) * active_threads);

--- a/orc-parser/reader.cc
+++ b/orc-parser/reader.cc
@@ -11,7 +11,7 @@
 #include <iostream>
 
 #define MIN(X, Y) ((X) < (Y) ? (X) : (Y)) 
-#define ROWS_PER_THREAD 100000
+#define ROWS_PER_THREAD 2000000
 
 using namespace orc;
 
@@ -52,7 +52,6 @@ void *read_thread(void *arg) {
 
 	// read the rows
 	uint64_t row_index_nums = ROWS_PER_THREAD / batch_size;	
-	std::cout<<"readings rows :" << args->start_row_number << " to: " << args->start_row_number + row_index_nums << "\n";
 	for (uint64_t row_index = 0; row_index < row_index_nums; row_index++) {
 		if (!rowReader->next(*batch))
 			break;
@@ -113,6 +112,13 @@ int main(int argc, char *argv[]) {
 
 	struct thread_args *thread_args = (struct thread_args *)malloc(sizeof(struct thread_args) * active_threads);
 	pthread_t *threads = (pthread_t *)malloc(sizeof(pthread_t) * active_threads);
+
+	// check how many rows belong to each stripe
+	for (uint64_t i=0; i<num_stripes;i++) {
+		uint64_t row_number = reader->getStripe(i)->getNumberOfRows();
+	std::cout<<"row number for stripe "<<i<<" : "<<row_number<<"\n";
+	
+	}
 
 	std::cout << "total num rows: " << total_num_rows << "\n";
 	std::cout << "Num stripes: " << num_stripes << "\n";

--- a/snappy/pim-snappy/dpu_task.c
+++ b/snappy/pim-snappy/dpu_task.c
@@ -16,6 +16,7 @@ __host uint32_t req_idx[NR_TASKLETS];
 __host uint32_t input_length[NR_TASKLETS];
 __host uint32_t output_length[NR_TASKLETS];
 __host uint32_t retval[NR_TASKLETS];
+__host uint32_t perf;
 
 // MRAM buffers
 uint8_t __mram_noinit input_buffer[NR_TASKLETS][MAX_INPUT_SIZE];
@@ -73,6 +74,7 @@ int main()
 #else
 	printf("Tasklet %d: %ld instructions, %d bytes\n", idx, perfcounter_get(), output.length);
 #endif	
+	perf = perfcounter_get();
 	retval[idx] = 1;
 	return 0;
 }

--- a/snappy/pim-snappy/pim_snappy.c
+++ b/snappy/pim-snappy/pim_snappy.c
@@ -32,6 +32,8 @@
 #define DPU_ID_SLICE(_x) ((_x >> 8) & 0xFF)
 #define DPU_ID_DPU(_x) ((_x) & 0xFF)
 
+#define DPU_CLOCK_CYCLE 266000000// TODO: confirm this
+
 // Buffer context struct for input and output buffers on host
 typedef struct host_buffer_context
 {
@@ -426,7 +428,7 @@ void pim_deinit(void) {
 	uint32_t rank_id = 0;
 	DPU_RANK_FOREACH(dpus, dpu_rank) {
 		host_rank_context* rank_ctx = &ctx[rank_id];
-		printf("total number of cycles of dpu 0 in rank %d: %d", rank_id, rank_ctx->dpus[0].perf);
+		printf("total number of seconds of operation of dpu 0 in rank %d: %lf\n", rank_id, double(rank_ctx->dpus[0].perf)/);
 		rank_id++;
 	}
 	// Signal to terminate the dpu master thread

--- a/snappy/pim-snappy/pim_snappy.c
+++ b/snappy/pim-snappy/pim_snappy.c
@@ -362,7 +362,6 @@ static void * dpu_uncompress(void *arg) {
 /*************************************************/
 
 int pim_init(void) {
-	//struct dpu_set_t dpu_rank; 
 	// Allocate all DPUs, then check how many were allocated
 	DPU_ASSERT(dpu_alloc(DPU_ALLOCATE_ALL, NULL, &dpus));
 	
@@ -418,6 +417,7 @@ int pim_init(void) {
 }
 
 void pim_deinit(void) {
+#ifdef STATISTICS
 	// get DPU stats 
 	uint32_t rank_id = 0;
 	double total_dpu_perf = 0.0;
@@ -432,6 +432,7 @@ void pim_deinit(void) {
 		rank_id++;
 	}
 	printf("total runtime of all ranks %lf\n", total_dpu_perf);
+#endif
 	// Signal to terminate the dpu master thread
 	pthread_mutex_lock(&mutex);
 	args.stop_thread = 1;

--- a/snappy/pim-snappy/pim_snappy.c
+++ b/snappy/pim-snappy/pim_snappy.c
@@ -32,6 +32,8 @@
 #define DPU_ID_SLICE(_x) ((_x >> 8) & 0xFF)
 #define DPU_ID_DPU(_x) ((_x) & 0xFF)
 
+#define DPU_CLOCK_CYCLE 266000000// TODO: confirm this
+
 // Buffer context struct for input and output buffers on host
 typedef struct host_buffer_context
 {
@@ -436,7 +438,7 @@ void pim_deinit(void) {
 	uint32_t rank_id = 0;
 	DPU_RANK_FOREACH(dpus, dpu_rank) {
 		host_rank_context* rank_ctx = &ctx[rank_id];
-		printf("total number of cycles of dpu 0 in rank %d: %d", rank_id, rank_ctx->dpus[0].perf);
+		printf("total number of seconds of operation of dpu 0 in rank %d: %lf\n", rank_id, double(rank_ctx->dpus[0].perf)/);
 		rank_id++;
 	}
 	// Signal to terminate the dpu master thread

--- a/snappy/pim-snappy/pim_snappy.c
+++ b/snappy/pim-snappy/pim_snappy.c
@@ -73,7 +73,7 @@ typedef struct master_args {
  } host_rank_context;
 
 // Stores number of allocated DPUs
-static struct dpu_set_t dpus;
+static struct dpu_set_t dpus, dpu_rank;
 static uint32_t num_ranks = 0;
 static uint32_t num_dpus = 0;
 
@@ -362,7 +362,7 @@ static void * dpu_uncompress(void *arg) {
 /*************************************************/
 
 int pim_init(void) {
-	struct dpu_set_t dpu_rank; 
+	//struct dpu_set_t dpu_rank; 
 	// Allocate all DPUs, then check how many were allocated
 	DPU_ASSERT(dpu_alloc(DPU_ALLOCATE_ALL, NULL, &dpus));
 	
@@ -419,7 +419,6 @@ int pim_init(void) {
 
 void pim_deinit(void) {
 	// get DPU stats 
-	struct dpu_set_t dpu_rank; 
 	uint32_t rank_id = 0;
 	double total_dpu_perf = 0.0;
 	DPU_RANK_FOREACH(dpus, dpu_rank) {

--- a/snappy/pim-snappy/pim_snappy.c
+++ b/snappy/pim-snappy/pim_snappy.c
@@ -85,7 +85,6 @@ static pthread_cond_t dpu_cond;
 static pthread_t dpu_master_thread;
 static master_args_t args;
 static uint32_t total_request_slots = 0;
-static double total_rank_time = 0; // TESTING, DELETE
 
 // Performance metrics
 static struct host_rank_context *ctx;
@@ -294,7 +293,6 @@ static void * dpu_uncompress(void *arg) {
 
 	struct timespec time_to_wait;
 	struct timeval first, second;
-	struct timeval load,unload;
 	uint32_t ranks_dispatched = 0;
 	while (args->stop_thread != 1) { 
 		pthread_mutex_lock(&mutex);
@@ -329,8 +327,6 @@ static void * dpu_uncompress(void *arg) {
 					// get rank_context
 					host_rank_context* rank_ctx = &ctx[rank_id];
 					unload_rank(&dpu_rank, args, rank_ctx);
-					gettimeofday(&unload, NULL);
-					total_rank_time += timediff(&load, &unload);
 					pthread_mutex_unlock(&mutex);
 			
 					ranks_dispatched &= ~(1 << rank_id);

--- a/snappy/pim-snappy/pim_snappy.c
+++ b/snappy/pim-snappy/pim_snappy.c
@@ -72,6 +72,7 @@ static pthread_cond_t dpu_cond;
 static pthread_t dpu_master_thread;
 static master_args_t args;
 static uint32_t total_request_slots = 0;
+static double total_rank_time = 0; // TESTING, DELETE
 
 /**
  * Attempt to read a varint from the input buffer. The format of a varint

--- a/snappy/pim-snappy/pim_snappy.c
+++ b/snappy/pim-snappy/pim_snappy.c
@@ -59,6 +59,17 @@ typedef struct master_args {
 	caller_args_t **caller_args;    // Request buffer
 } master_args_t;
 
+// Descriptors for DPUs for performance metrics
+ typedef struct host_dpu_descriptor {
+ 	uint32_t perf; // value from the DPU's performance counter
+ } host_dpu_descriptor;
+
+ // Rank context struct for performance metrics
+ typedef struct host_rank_context {
+ 	uint32_t dpu_count; // how many dpus are filled in the descriptor array
+ 	host_dpu_descriptor *dpus; // the descriptors for the dpus in this rank
+ } host_rank_context;
+
 // Stores number of allocated DPUs
 static struct dpu_set_t dpus;
 static uint32_t num_ranks = 0;
@@ -73,6 +84,11 @@ static pthread_t dpu_master_thread;
 static master_args_t args;
 static uint32_t total_request_slots = 0;
 static double total_rank_time = 0; // TESTING, DELETE
+
+// Performance metrics
+static struct host_rank_context *ctx;
+static uint32_t dpus_per_rank;
+
 
 /**
  * Attempt to read a varint from the input buffer. The format of a varint
@@ -216,13 +232,16 @@ static void load_rank(struct dpu_set_t *dpu_rank, master_args_t *args) {
  * @param dpu_rank: pointer to DPU rank handle to unload
  * @param args: pointer to the DPU handler thread args
  */
-static void unload_rank(struct dpu_set_t *dpu_rank, master_args_t *args) {
+static void unload_rank(struct dpu_set_t *dpu_rank, master_args_t *args, struct host_rank_context *rank_ctx) {
 	struct dpu_set_t dpu;
+	uint8_t dpu_id;
+
 	uint32_t output_length = 0;
 	for (int i = 0; i < NR_TASKLETS; i++) {
 		// Get the decompressed buffer
 		uint32_t dpu_count = 0;
-		DPU_FOREACH(*dpu_rank, dpu) {
+		uint32_t perf = 0;
+		DPU_FOREACH(*dpu_rank, dpu, dpu_id) {
 			output_length = 0;
 			DPU_ASSERT(dpu_copy_from(dpu, "output_length", i * sizeof(uint32_t), &output_length, sizeof(uint32_t)));
 			if (output_length == 0)
@@ -238,6 +257,9 @@ static void unload_rank(struct dpu_set_t *dpu_rank, master_args_t *args) {
 			// Get the return value
 			DPU_ASSERT(dpu_copy_from(dpu, "retval", i * sizeof(uint32_t), &(args->caller_args[req_idx]->retval), sizeof(uint32_t)));
 			args->caller_args[req_idx]->data_ready = 0;
+			// Get the performance metric
+			DPU_ASSERT(dpu_copy_from(dpu, "perf", i * sizeof(uint32_t), &perf, sizeof(uint32_t)));
+			rank_ctx->dpus[dpu_id].perf += perf; // cumulative performance
 			// Set up the transfer
 			DPU_ASSERT(dpu_prepare_xfer(dpu, (void *)args->caller_args[req_idx]->output->curr));
 			dpu_count++;
@@ -301,7 +323,13 @@ static void * dpu_uncompress(void *arg) {
 			if (ranks_dispatched & (1 << rank_id)) {
 				if (free_ranks & (1 << rank_id)) {
 					pthread_mutex_lock(&mutex);
-					unload_rank(&dpu_rank, args);
+					// get rank_context
+					host_rank_context* rank_ctx = &ctx[rank_id];
+					unload_rank(&dpu_rank, args, rank_ctx);
+					gettimeofday(&unload, NULL);
+					// printf("unloading %ld %lf\n", rank_id, timediff(&load, &unload));
+					total_rank_time += timediff(&load, &unload);
+					printf("total_rank time so far %f\n", total_rank_time);
 					pthread_mutex_unlock(&mutex);
 			
 					ranks_dispatched &= ~(1 << rank_id);
@@ -337,11 +365,13 @@ static void * dpu_uncompress(void *arg) {
 /*************************************************/
 
 int pim_init(void) {
+	struct dpu_set_t dpu_rank; 
 	// Allocate all DPUs, then check how many were allocated
 	DPU_ASSERT(dpu_alloc(DPU_ALLOCATE_ALL, NULL, &dpus));
 	
 	dpu_get_nr_ranks(dpus, &num_ranks);
 	dpu_get_nr_dpus(dpus, &num_dpus);
+	dpus_per_rank = num_dpus / num_ranks;
 	total_request_slots = num_dpus * NR_TASKLETS;
 
 	// Load the program to all DPUs
@@ -354,6 +384,17 @@ int pim_init(void) {
 	args.req_count = 0;
 	args.req_waiting = 0;
 	args.caller_args = (caller_args_t **)malloc(sizeof(caller_args_t *) * total_request_slots);
+
+	// allocate space for DPU descriptors for all ranks
+	ctx = calloc(num_ranks, sizeof(host_rank_context));
+	// allocate space for dpu descriptors for all dpus in every rank
+	uint32_t rank_id = 0;
+	DPU_RANK_FOREACH(dpus, dpu_rank) {
+		struct host_dpu_descriptor *rank_input;
+		rank_input = calloc(dpus_per_rank, sizeof(struct host_dpu_descriptor));
+		ctx[rank_id].dpus = rank_input;
+		rank_id++;
+	}
 	
 	if (pthread_create(&dpu_master_thread, NULL, dpu_uncompress, &args) != 0) {
 		fprintf(stderr, "Failed to create dpu_decompress pthreads\n");
@@ -380,6 +421,14 @@ int pim_init(void) {
 }
 
 void pim_deinit(void) {
+	// get DPU stats 
+	struct dpu_set_t dpu_rank; 
+	uint32_t rank_id = 0;
+	DPU_RANK_FOREACH(dpus, dpu_rank) {
+		host_rank_context* rank_ctx = &ctx[rank_id];
+		printf("total number of cycles of dpu 0 in rank %d: %d", rank_id, rank_ctx->dpus[0].perf);
+		rank_id++;
+	}
 	// Signal to terminate the dpu master thread
 	pthread_mutex_lock(&mutex);
 	args.stop_thread = 1;

--- a/snappy/pim-snappy/pim_snappy.c
+++ b/snappy/pim-snappy/pim_snappy.c
@@ -332,7 +332,7 @@ static void * dpu_uncompress(void *arg) {
 				if (free_ranks & (1 << rank_id)) {
 					pthread_mutex_lock(&mutex);
 					// get rank_context
-					struct host_rank_context rank_ctx = ctx[rank_id];
+					struct* host_rank_context rank_ctx = &ctx[rank_id];
 					unload_rank(&dpu_rank, args, rank_ctx);
 					gettimeofday(&unload, NULL);
 					// printf("unloading %ld %lf\n", rank_id, timediff(&load, &unload));
@@ -402,7 +402,7 @@ int pim_init(void) {
 	DPU_RANK_FOREACH(dpus, dpu_rank) {
 		struct host_dpu_descriptor *rank_input;
 		rank_input = calloc(dpus_per_rank, sizeof(struct host_dpu_descriptor));
-		*ctx[rank_id] = rank_input;
+		ctx[rank_id] = &rank_input;
 		rank_id++;
 	}
 	

--- a/snappy/pim-snappy/pim_snappy.c
+++ b/snappy/pim-snappy/pim_snappy.c
@@ -284,6 +284,7 @@ static void * dpu_uncompress(void *arg) {
 
 	struct timespec time_to_wait;
 	struct timeval first, second;
+	struct timeval load,unload;
 	uint32_t ranks_dispatched = 0;
 	while (args->stop_thread != 1) { 
 		pthread_mutex_lock(&mutex);
@@ -317,7 +318,8 @@ static void * dpu_uncompress(void *arg) {
 				if (free_ranks & (1 << rank_id)) {
 					pthread_mutex_lock(&mutex);
 					unload_rank(&dpu_rank, args);
-					// printf("Handler2\n");
+					gettimeofday(&unload, NULL);
+					printf("unloading %ld %lf\n", rank_id, timediff(&load, &unload));
 					pthread_mutex_unlock(&mutex);
 			
 					ranks_dispatched &= ~(1 << rank_id);
@@ -335,9 +337,9 @@ static void * dpu_uncompress(void *arg) {
 			DPU_RANK_FOREACH(dpus, dpu_rank) {
 				if ((free_ranks & (1 << rank_id)) && args->req_waiting) {
 					pthread_mutex_lock(&mutex);
-					// printf("Handler4\n");
+					gettimeofday(&load, NULL);
 					load_rank(&dpu_rank, args);
-					// printf("Handler4.2\n");
+					printf("load %ld\n", rank_id);
 					pthread_mutex_unlock(&mutex);
 
 					ranks_dispatched |= (1 << rank_id);
@@ -345,7 +347,6 @@ static void * dpu_uncompress(void *arg) {
 				rank_id++;
 			}
 		}
-		// printf("Handler5\n");
 	}	
 
 	return NULL;

--- a/snappy/pim-snappy/pim_snappy.c
+++ b/snappy/pim-snappy/pim_snappy.c
@@ -329,9 +329,7 @@ static void * dpu_uncompress(void *arg) {
 					host_rank_context* rank_ctx = &ctx[rank_id];
 					unload_rank(&dpu_rank, args, rank_ctx);
 					gettimeofday(&unload, NULL);
-					// printf("unloading %ld %lf\n", rank_id, timediff(&load, &unload));
 					total_rank_time += timediff(&load, &unload);
-					printf("total_rank time so far %f\n", total_rank_time);
 					pthread_mutex_unlock(&mutex);
 			
 					ranks_dispatched &= ~(1 << rank_id);
@@ -426,11 +424,18 @@ void pim_deinit(void) {
 	// get DPU stats 
 	struct dpu_set_t dpu_rank; 
 	uint32_t rank_id = 0;
+	double total_dpu_perf = 0.0;
 	DPU_RANK_FOREACH(dpus, dpu_rank) {
 		host_rank_context* rank_ctx = &ctx[rank_id];
-		printf("total number of seconds of operation of dpu 0 in rank %d: %lf\n", rank_id, double(rank_ctx->dpus[0].perf)/);
+		double max_perf_rank = 0.0;
+		for (uint32_t dpu_id=0; dpu_id < dpus_per_rank; dpu_id++) {
+			max_perf_rank = MAX((double)rank_ctx->dpus[dpu_id].perf/DPU_CLOCK_CYCLE, max_perf_rank);
+		}
+		printf("max runtime of all DPUs in rank %d: %lf\n", rank_id, max_perf_rank);
+		total_dpu_perf += max_perf_rank;
 		rank_id++;
 	}
+	printf("total runtime of all ranks %lf\n", total_dpu_perf);
 	// Signal to terminate the dpu master thread
 	pthread_mutex_lock(&mutex);
 	args.stop_thread = 1;

--- a/snappy/pim-snappy/pim_snappy.c
+++ b/snappy/pim-snappy/pim_snappy.c
@@ -332,7 +332,7 @@ static void * dpu_uncompress(void *arg) {
 				if (free_ranks & (1 << rank_id)) {
 					pthread_mutex_lock(&mutex);
 					// get rank_context
-					struct* host_rank_context rank_ctx = &ctx[rank_id];
+					host_rank_context* rank_ctx = &ctx[rank_id];
 					unload_rank(&dpu_rank, args, rank_ctx);
 					gettimeofday(&unload, NULL);
 					// printf("unloading %ld %lf\n", rank_id, timediff(&load, &unload));
@@ -402,7 +402,7 @@ int pim_init(void) {
 	DPU_RANK_FOREACH(dpus, dpu_rank) {
 		struct host_dpu_descriptor *rank_input;
 		rank_input = calloc(dpus_per_rank, sizeof(struct host_dpu_descriptor));
-		ctx[rank_id] = &rank_input;
+		ctx[rank_id].dpus = rank_input;
 		rank_id++;
 	}
 	


### PR DESCRIPTION
- added DPU runtime by recording number of cycles of each DPU during each round and then finding the maximum value. You can define #statistics in pim_snappy.c to be able to see the print statements stating DPU stat.
- changed the reader so that more threads can be assigned. -t does not represent number of threads anymore. It is a multiple of the stride size of the snappy reader. I made the stride size to be the minimum number of rows assigned to one thread. If you want to lower this number, make sure you look into it to make sure no data is lost. 